### PR TITLE
Add loading start screen

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -35,7 +35,7 @@ const Navbar = () => {
     <nav
       className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
         isScrolled
-          ? "bg-white/90 backdrop-blur-md shadow-sm"
+          ? "bg-sky-300/90 backdrop-blur-md shadow-sm"
           : "bg-transparent"
       }`}
     >
@@ -75,7 +75,7 @@ const Navbar = () => {
 
       {/* Menú móvil */}
       {isOpen && (
-        <div className="md:hidden bg-white/95 backdrop-blur-md">
+        <div className="md:hidden bg-sky-300/95 backdrop-blur-md">
           <div className="px-4 pt-2 pb-4 space-y-1">
             {navLinks.map((link) => (
               <a

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/index.css
+++ b/src/index.css
@@ -139,3 +139,30 @@
     @apply opacity-100 translate-y-0;
   }
 }
+@keyframes glow {
+  0% {
+    opacity: 0;
+    transform: translateY(-20px);
+    text-shadow: 0 0 5px rgba(6, 182, 212, 0.5);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+    text-shadow: 0 0 15px rgba(6, 182, 212, 0.8);
+  }
+}
+
+@layer utilities {
+  .animate-glow {
+    animation: glow 0.8s ease forwards;
+  }
+
+  .tech-loader {
+    @apply w-16 h-16 border-4 border-white/20 border-t-cyan-400 rounded-full animate-spin;
+  }
+
+  .btn-start {
+    @apply bg-cyan-600 text-white px-8 py-3 rounded-md transition-transform duration-300 shadow-lg hover:bg-cyan-500 hover:shadow-xl active:scale-95 focus:outline-none focus:ring-2 focus:ring-cyan-300;
+  }
+}
+

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import Navbar from "@/components/Navbar";
 import HeroSection from "@/components/HeroSection";
 import AboutSection from "@/components/AboutSection";
@@ -8,12 +8,21 @@ import ContactSection from "@/components/ContactSection";
 import FooterSection from "@/components/FooterSection";
 import ScrollToTopButton from "@/components/ScrollToTopButton";
 import { initScrollReveal } from "@/utils/ScrollReveal";
+import StartScreen from "./StartScreen";
 
 const Index = () => {
+  const [started, setStarted] = useState(false);
+
   useEffect(() => {
-    // Inicializar el efecto de ScrollReveal
-    initScrollReveal();
-  }, []);
+    if (started) {
+      // Inicializar el efecto de ScrollReveal una vez iniciada la misión
+      initScrollReveal();
+    }
+  }, [started]);
+
+  if (!started) {
+    return <StartScreen onStart={() => setStarted(true)} />;
+  }
 
   return (
     <div className="min-h-screen">

--- a/src/pages/StartScreen.tsx
+++ b/src/pages/StartScreen.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+interface StartScreenProps {
+  onStart: () => void;
+}
+
+const StartScreen = ({ onStart }: StartScreenProps) => {
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setLoading(false), 2000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-gray-950 via-gray-900 to-gray-950 text-white">
+      {loading ? (
+        <div className="tech-loader" />
+      ) : (
+        <>
+          <h1 className="text-4xl md:text-5xl font-bold mb-8 animate-glow">Bienvenido</h1>
+          <Button onClick={onStart} className="btn-start text-lg font-medium">
+            Iniciar misión
+          </Button>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default StartScreen;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -127,5 +128,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- implement `StartScreen` with tech-style loader, glowing title, and animated button
- integrate `StartScreen` in main page
- fix ESLint errors about empty interfaces
- convert Tailwind plugin import to ES module
- define custom glow animation and button styles

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6848b4a16d6483228aa00be9b5955a23